### PR TITLE
Fix MixMachine.Format.Sarif.normalize/1 for {line, col}

### DIFF
--- a/lib/mix_machine/format/sarif.ex
+++ b/lib/mix_machine/format/sarif.ex
@@ -104,5 +104,6 @@ defmodule MixMachine.Format.Sarif do
 
   defp normalize(nil), do: {1, 1, 1, 1}
   defp normalize(line) when is_integer(line), do: {line, 1, line, 1}
+  defp normalize({line, col}), do: {line, col, line, col}
   defp normalize(tuple), do: tuple
 end


### PR DESCRIPTION
Hi!

As of now `mix compile.machine` at

```
Erlang/OTP 26 [erts-14.2.5] [source] [64-bit] [smp:12:12] [ds:12:12:10] [async-threads:1] [dtrace]

Elixir 1.17.2 (compiled with Erlang/OTP 26)
```

fails due to match error in `MixMachine.Format.Sarif.normalize/1`.

I've patched it to handle `{line, col}` tuples.

Tho I'm unsure of SARIF requirements, however judging by the way it is implemented RN, it should be fine

